### PR TITLE
Fehlenden Stadtcode für Regensburg eingefügt: Germany / Bayern / R. B…

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -15,7 +15,7 @@
   },
   "Germany": {
       "Baden-Württemberg": ["BW", "AA", "AB", "BC", "BL", "FR", "HD", "HN", "KA", "LB", "RT", "S", "TÜ", "UL", "WN", "ZAK"],
-      "Bayern": ["BY","A", "AB", "AN", "AÖ", "AS", "BA", "BT", "BY", "CO", "DON", "EBE", "ER", "FS", "IN", "KG", "LA", "M", "N", "PAF", "REG", "RO", "SAD", "SOB", "SR", "TIR", "TS", "WÜ"],
+      "Bayern": ["BY","A", "AB", "AN", "AÖ", "AS", "BA", "BT", "BY", "CO", "DON", "EBE", "ER", "FS", "IN", "KG", "LA", "M", "N", "PAF", "R", "REG", "RO", "SAD", "SOB", "SR", "TIR", "TS", "WÜ"],
       "Berlin": ["BE","B"],
       "Brandenburg": ["BB","BAR", "BRB", "CB", "EE", "FF", "HVL", "LDS", "LÜB", "MOL", "P", "PIR", "SPN"],
       "Bremen": ["HB", "BH"],


### PR DESCRIPTION
…isher war nur der Code "REG" drin; der steht aber für den Landkreis "Regen" in Bayern, nicht für Regensburg.

Mein Name ist Franz Häring. Ich habe gestern eine Kamerafalle in Betrieb genommen. Der Standort ist Neutraubling im Landkreis Regensburg, Bayern. Den LEPMON Code konnte ich wegen der fehlenden Wahlmöglichkeit "R" nicht korrekt einstellen.